### PR TITLE
config for nio.conf user defined

### DIFF
--- a/nio_cli/commands/config.py
+++ b/nio_cli/commands/config.py
@@ -6,7 +6,7 @@ import tempfile
 
 
 def config_project(name='.'):
-    env_location = '{}/nio.env'.format(name)
+    env_location = '{}/nio.conf'.format(name)
     if not os.path.isfile(env_location):
         print("Command must be run from project root.")
         return
@@ -18,12 +18,12 @@ def config_project(name='.'):
     with open(env_location, 'r') as nenv,\
      tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
         for line in nenv:
-            if re.search('^PK_HOST:', line) and pk_host:
-                tmp.write('PK_HOST: {}\n'.format(pk_host))
-            elif re.search('^WS_HOST:', line) and pk_host:
-                tmp.write('WS_HOST: {}\n'.format(ws_host))
-            elif re.search('^PK_TOKEN:', line) and pk_token:
-                tmp.write('PK_TOKEN: {}\n'.format(pk_token))
+            if re.search('^PK_HOST=', line) and pk_host:
+                tmp.write('PK_HOST={}\n'.format(pk_host))
+            elif re.search('^WS_HOST=', line) and pk_host:
+                tmp.write('WS_HOST={}\n'.format(ws_host))
+            elif re.search('^PK_TOKEN=', line) and pk_token:
+                tmp.write('PK_TOKEN={}\n'.format(pk_token))
             else:
                 tmp.write(line)
         os.remove(env_location)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,7 +111,7 @@ class TestCLI(unittest.TestCase):
                         with patch('nio_cli.commands.config.os.remove') as remove:
                             self._main('config')
                             self.assertEqual(mopen.call_count, 1)
-                            remove.assert_called_once_with('./nio.env')
+                            remove.assert_called_once_with('./nio.conf')
                             self.assertEqual(rename.call_count, 1)
 
     def test_config_with_no_nioenv(self):


### PR DESCRIPTION
Half of this PR relies on [60](https://github.com/niolabs/project_template/pull/60) from the project_template. Probably also [229](https://github.com/niolabs/nio-core/pull/229) in nio-core? 

With the current changes to the project_template, `nio new` will not work until those are merged. It looks like this new configuration won't work until a new binary is released as well?