### PR TITLE
close tmp file before rename

### DIFF
--- a/nio_cli/commands/config.py
+++ b/nio_cli/commands/config.py
@@ -26,8 +26,8 @@ def config_project(name='.'):
                 tmp.write('PK_TOKEN={}\n'.format(pk_token))
             else:
                 tmp.write(line)
-        os.remove(env_location)
-        os.rename(tmp.name, env_location)
+    os.remove(env_location)
+    os.rename(tmp.name, env_location)
 
 
 class Config(Base):


### PR DESCRIPTION
https://poweredbynio.slack.com/archives/G8P5173MF/p1517245727000021
during new/config cli operations:
```
Enter PK Host (optional): foo
Enter PK Token (optional): bar
Traceback (most recent call last):
  File "C:\Users\Tom\AppData\Local\Programs\Python\Python36\Scripts\nio-script.py", line 11, in <module>
    load_entry_point('nio-cli', 'console_scripts', 'nio')()
  File "c:\users\tom\nio\nio-cli\nio_cli\cli.py", line 58, in main
    command(options).run()
  File "c:\users\tom\nio\nio-cli\nio_cli\commands\new.py", line 36, in run
    config_project(self._name)
  File "c:\users\tom\nio\nio-cli\nio_cli\commands\config.py", line 29, in config_project
    os.remove(env_location)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'wtf
z/nio.conf'
```