### PR TITLE
Nio 1055 id prep

### DIFF
--- a/nio_cli/commands/list.py
+++ b/nio_cli/commands/list.py
@@ -13,6 +13,10 @@ class List(Base):
         response = requests.get(self._base_url.format(self._resource),
                                 auth=self._auth)
         try:
-            [print(resource) for resource in response.json()]
+            [print(value['id'], value['name']) for key,
+                                    value in response.json().items()]
         except:
-            pass
+            try:
+                [print(resource) for resource in response.json()]
+            except:
+                pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,22 @@ class TestCLI(unittest.TestCase):
                     print.call_args_list[index][0][0], service)
 
     @responses.activate
+    def test_list_command_with_id(self):
+        """List blocks or services from the rest api"""
+        block_response = [{'id1': {'name': 'name1', 'id': 'id1'},
+                           'id2': {'name': 'name2', 'id': 'id2'}}]
+        responses.add(responses.GET,
+                      'http://127.0.0.1:8181/blocks',
+                      json=block_response)
+        with patch('builtins.print') as print:
+            self._main('list', services=False)
+            self.assertEqual(len(responses.calls), 1)
+            self.assertEqual(print.call_count, len(block_response))
+            for index, block in enumerate(block_response):
+                self.assertDictEqual(
+                    print.call_args_list[index][0][0], block)
+
+    @responses.activate
     def test_shutdown_command(self):
         """Shutdown nio through the rest api"""
         responses.add(responses.GET, 'http://127.0.0.1:8181/shutdown')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,18 +198,20 @@ class TestCLI(unittest.TestCase):
     @responses.activate
     def test_list_command_with_id(self):
         """List blocks or services from the rest api"""
-        block_response = [{'id1': {'name': 'name1', 'id': 'id1'},
-                           'id2': {'name': 'name2', 'id': 'id2'}}]
+        blk_response = {'id1': {'name': 'name1', 'id': 'id1'},
+                        'id2': {'name': 'name2', 'id': 'id2'}}
         responses.add(responses.GET,
                       'http://127.0.0.1:8181/blocks',
-                      json=block_response)
+                      json=blk_response)
         with patch('builtins.print') as print:
             self._main('list', services=False)
             self.assertEqual(len(responses.calls), 1)
-            self.assertEqual(print.call_count, len(block_response))
-            for index, block in enumerate(block_response):
-                self.assertDictEqual(
-                    print.call_args_list[index][0][0], block)
+            self.assertEqual(print.call_count, 2)
+            for index, blk in enumerate(blk_response):
+                self.assertEqual(
+                    print.call_args_list[index],
+                    ((blk_response[blk]['id'], blk_response[blk]['name']),)
+                )
 
     @responses.activate
     def test_shutdown_command(self):


### PR DESCRIPTION
Small change to make the output of `nio list blocks/services` a bit more human friendly with the addition of block and service ids. This should be fully backwards compatible with old binaries. Additional comments below for some questions. 