### PR TITLE
Auto-generate CHANGELOG.md for nio-cli

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,5 @@
+since-tag=0.4.4
+add_issues_wo_labels=false
+add_pr_wo_labels=false
+enhancement_prefix=**Added features:**
+include_labels=bug,enhancement,deprecated,removed,security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,196 @@
+# Change Log
+
+## [0.5.5](https://github.com/niolabs/nio-cli/tree/0.5.5) (2018-03-15)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.4...0.5.5)
+
+**Merged pull requests:**
+
+- nio new command searches project template for requirements.txt and installs libraries [\#87](https://github.com/niolabs/nio-cli/pull/87) ([cowleyk](https://github.com/cowleyk))
+- Add optional SSL cert generation and secure instance configuration [\#73](https://github.com/niolabs/nio-cli/pull/73) ([nioJake](https://github.com/nioJake))
+
+## [0.5.4](https://github.com/niolabs/nio-cli/tree/0.5.4) (2018-02-05)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.3...0.5.4)
+
+**Closed issues:**
+
+- missing pep8 requirement [\#75](https://github.com/niolabs/nio-cli/issues/75)
+- requirements for testing [\#74](https://github.com/niolabs/nio-cli/issues/74)
+- Link to docs in --help [\#17](https://github.com/niolabs/nio-cli/issues/17)
+
+**Merged pull requests:**
+
+- PK -\> Pubkeeper logging changes [\#82](https://github.com/niolabs/nio-cli/pull/82) ([tlugger](https://github.com/tlugger))
+- add dev requirements close \#74 [\#81](https://github.com/niolabs/nio-cli/pull/81) ([tyoungNIO](https://github.com/tyoungNIO))
+- Pep8 req close \#75 [\#80](https://github.com/niolabs/nio-cli/pull/80) ([tyoungNIO](https://github.com/tyoungNIO))
+- remove dot in nio [\#79](https://github.com/niolabs/nio-cli/pull/79) ([jennyknuth](https://github.com/jennyknuth))
+- add docs link to help close \#17 [\#78](https://github.com/niolabs/nio-cli/pull/78) ([tyoungNIO](https://github.com/tyoungNIO))
+
+## [0.5.3](https://github.com/niolabs/nio-cli/tree/0.5.3) (2018-01-29)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.2...0.5.3)
+
+**Closed issues:**
+
+- nio server eats up 100% of CPU [\#24](https://github.com/niolabs/nio-cli/issues/24)
+- Update blocks should not reinitialize the submodules [\#23](https://github.com/niolabs/nio-cli/issues/23)
+- Server action should have a project location param [\#20](https://github.com/niolabs/nio-cli/issues/20)
+- Use pynio for nio api calls [\#4](https://github.com/niolabs/nio-cli/issues/4)
+
+**Merged pull requests:**
+
+- close tmp file before rename [\#76](https://github.com/niolabs/nio-cli/pull/76) ([tyoungNIO](https://github.com/tyoungNIO))
+
+## [0.5.2](https://github.com/niolabs/nio-cli/tree/0.5.2) (2018-01-26)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.1...0.5.2)
+
+**Merged pull requests:**
+
+- config for nio.conf user defined [\#72](https://github.com/niolabs/nio-cli/pull/72) ([tlugger](https://github.com/tlugger))
+
+## [0.5.1](https://github.com/niolabs/nio-cli/tree/0.5.1) (2018-01-24)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.0...0.5.1)
+
+**Merged pull requests:**
+
+- refactor configure to not use sed [\#71](https://github.com/niolabs/nio-cli/pull/71) ([tlugger](https://github.com/tlugger))
+- fix niolabs and cli docs links [\#70](https://github.com/niolabs/nio-cli/pull/70) ([ssclay](https://github.com/ssclay))
+- Add seperator between blocks in buildreadme [\#69](https://github.com/niolabs/nio-cli/pull/69) ([hansmosh](https://github.com/hansmosh))
+- Handle failed git clone on 'nio new' [\#68](https://github.com/niolabs/nio-cli/pull/68) ([hansmosh](https://github.com/hansmosh))
+- Update install\_requires [\#67](https://github.com/niolabs/nio-cli/pull/67) ([hansmosh](https://github.com/hansmosh))
+
+## [0.5.0](https://github.com/niolabs/nio-cli/tree/0.5.0) (2018-01-05)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.4...0.5.0)
+
+**Merged pull requests:**
+
+- Config project [\#66](https://github.com/niolabs/nio-cli/pull/66) ([tlugger](https://github.com/tlugger))
+- Launch items [\#65](https://github.com/niolabs/nio-cli/pull/65) ([tlugger](https://github.com/tlugger))
+
+## [0.4.4](https://github.com/niolabs/nio-cli/tree/0.4.4) (2018-01-05)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.3...0.4.4)
+
+**Merged pull requests:**
+
+- command cleanup [\#64](https://github.com/niolabs/nio-cli/pull/64) ([tlugger](https://github.com/tlugger))
+- nio\_run -\> niod [\#63](https://github.com/niolabs/nio-cli/pull/63) ([tlugger](https://github.com/tlugger))
+
+## [0.4.3](https://github.com/niolabs/nio-cli/tree/0.4.3) (2018-01-03)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.2...0.4.3)
+
+**Merged pull requests:**
+
+- :sparkles: Buildspec command adds categories to each block [\#61](https://github.com/niolabs/nio-cli/pull/61) ([cowleyk](https://github.com/cowleyk))
+
+## [0.4.2](https://github.com/niolabs/nio-cli/tree/0.4.2) (2017-10-23)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.1...0.4.2)
+
+**Closed issues:**
+
+- Use git:// for git dependent commmands [\#60](https://github.com/niolabs/nio-cli/issues/60)
+
+**Merged pull requests:**
+
+- niolabs and git command updates [\#59](https://github.com/niolabs/nio-cli/pull/59) ([tlugger](https://github.com/tlugger))
+- Support multiple git remote formats for buildrelease [\#58](https://github.com/niolabs/nio-cli/pull/58) ([hansmosh](https://github.com/hansmosh))
+- Handle version [\#57](https://github.com/niolabs/nio-cli/pull/57) ([cowleyk](https://github.com/cowleyk))
+- Don't require niocore for all commands [\#55](https://github.com/niolabs/nio-cli/pull/55) ([hansmosh](https://github.com/hansmosh))
+- Update release for term/gen blocks [\#54](https://github.com/niolabs/nio-cli/pull/54) ([cowleyk](https://github.com/cowleyk))
+- Import Base rather than Block [\#53](https://github.com/niolabs/nio-cli/pull/53) ([cowleyk](https://github.com/cowleyk))
+- Populate proper inputs/outputs from block [\#52](https://github.com/niolabs/nio-cli/pull/52) ([cowleyk](https://github.com/cowleyk))
+- Blockcheck BLK-290 [\#51](https://github.com/niolabs/nio-cli/pull/51) ([cowleyk](https://github.com/cowleyk))
+- Do not check for exception in version property [\#50](https://github.com/niolabs/nio-cli/pull/50) ([dorzel](https://github.com/dorzel))
+- Use https github url format in buildrelease command [\#49](https://github.com/niolabs/nio-cli/pull/49) ([dorzel](https://github.com/dorzel))
+- Add "None" to README for blank section [\#48](https://github.com/niolabs/nio-cli/pull/48) ([kyliedale](https://github.com/kyliedale))
+- buildreadme commands supports newer spec schema [\#45](https://github.com/niolabs/nio-cli/pull/45) ([hansmosh](https://github.com/hansmosh))
+- Auto populate commands key [\#44](https://github.com/niolabs/nio-cli/pull/44) ([cowleyk](https://github.com/cowleyk))
+- Alphabetize blocks [\#43](https://github.com/niolabs/nio-cli/pull/43) ([cowleyk](https://github.com/cowleyk))
+- Buildrelease Command [\#42](https://github.com/niolabs/nio-cli/pull/42) ([dorzel](https://github.com/dorzel))
+
+## [0.4.1](https://github.com/niolabs/nio-cli/tree/0.4.1) (2017-08-04)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.4...0.4.1)
+
+## [0.3.4](https://github.com/niolabs/nio-cli/tree/0.3.4) (2017-08-04)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.3...0.3.4)
+
+**Closed issues:**
+
+- All binary executable to be configurable for `nio server` [\#27](https://github.com/niolabs/nio-cli/issues/27)
+
+**Merged pull requests:**
+
+- Keys of properties dict are the variable name and include a title key [\#40](https://github.com/niolabs/nio-cli/pull/40) ([cowleyk](https://github.com/cowleyk))
+- Newblock command BLK-264 [\#39](https://github.com/niolabs/nio-cli/pull/39) ([cowleyk](https://github.com/cowleyk))
+- New project inits repo after clone BLK-265 [\#36](https://github.com/niolabs/nio-cli/pull/36) ([hansmosh](https://github.com/hansmosh))
+- Add buildreadme command BLK-274 [\#35](https://github.com/niolabs/nio-cli/pull/35) ([hansmosh](https://github.com/hansmosh))
+- Specjson script BLK-273 [\#34](https://github.com/niolabs/nio-cli/pull/34) ([hansmosh](https://github.com/hansmosh))
+- Refactor and improve unit tests BLK-267 [\#33](https://github.com/niolabs/nio-cli/pull/33) ([hansmosh](https://github.com/hansmosh))
+- Update config command [\#32](https://github.com/niolabs/nio-cli/pull/32) ([nioJake](https://github.com/nioJake))
+- Add clone command [\#31](https://github.com/niolabs/nio-cli/pull/31) ([nioJake](https://github.com/nioJake))
+- Make Server Command Configurable [\#30](https://github.com/niolabs/nio-cli/pull/30) ([dorzel](https://github.com/dorzel))
+
+## [0.3.3](https://github.com/niolabs/nio-cli/tree/0.3.3) (2017-04-17)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.1...0.3.3)
+
+**Closed issues:**
+
+- Don't default IP address to 0.0.0.0 [\#28](https://github.com/niolabs/nio-cli/issues/28)
+
+**Merged pull requests:**
+
+- Update default IP Address [\#29](https://github.com/niolabs/nio-cli/pull/29) ([mattdodge](https://github.com/mattdodge))
+
+## [0.3.1](https://github.com/niolabs/nio-cli/tree/0.3.1) (2016-06-16)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/v0.3.1...0.3.1)
+
+## [v0.3.1](https://github.com/niolabs/nio-cli/tree/v0.3.1) (2016-06-16)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/v0.3.0...v0.3.1)
+
+**Closed issues:**
+
+- For nio 2.0 start nio with `nio\_full` instead of `run\_nio` [\#26](https://github.com/niolabs/nio-cli/issues/26)
+
+## [v0.3.0](https://github.com/niolabs/nio-cli/tree/v0.3.0) (2016-06-16)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.2.0b1...v0.3.0)
+
+## [0.2.0b1](https://github.com/niolabs/nio-cli/tree/0.2.0b1) (2016-03-09)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.1.14...0.2.0b1)
+
+**Merged pull requests:**
+
+- Checkout appropriate project version tag on new project [\#25](https://github.com/niolabs/nio-cli/pull/25) ([hansmosh](https://github.com/hansmosh))
+
+## [0.1.14](https://github.com/niolabs/nio-cli/tree/0.1.14) (2015-06-04)
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.1.13...0.1.14)
+
+**Closed issues:**
+
+- nio server [\#9](https://github.com/niolabs/nio-cli/issues/9)
+
+**Merged pull requests:**
+
+- Making recursive install a classmethod [\#22](https://github.com/niolabs/nio-cli/pull/22) ([mattdodge](https://github.com/mattdodge))
+
+## [0.1.13](https://github.com/niolabs/nio-cli/tree/0.1.13) (2015-05-26)
+**Closed issues:**
+
+- Install from requirements files in submodules [\#12](https://github.com/niolabs/nio-cli/issues/12)
+- Install block dependencies when adding blocks [\#10](https://github.com/niolabs/nio-cli/issues/10)
+- Use only one config file [\#7](https://github.com/niolabs/nio-cli/issues/7)
+
+**Merged pull requests:**
+
+- Keeping version in \_\_init\_\_.py file [\#21](https://github.com/niolabs/nio-cli/pull/21) ([mattdodge](https://github.com/mattdodge))
+- Add background flag to server action [\#19](https://github.com/niolabs/nio-cli/pull/19) ([hansmosh](https://github.com/hansmosh))
+- Update repo for pypi [\#18](https://github.com/niolabs/nio-cli/pull/18) ([hansmosh](https://github.com/hansmosh))
+- Recurisvely install requirements from block repos [\#16](https://github.com/niolabs/nio-cli/pull/16) ([hansmosh](https://github.com/hansmosh))
+- Add 'nio server' command [\#15](https://github.com/niolabs/nio-cli/pull/15) ([hansmosh](https://github.com/hansmosh))
+- Read NIOHOST and NIOPORT from environements vars. Close \#7 [\#14](https://github.com/niolabs/nio-cli/pull/14) ([hansmosh](https://github.com/hansmosh))
+- Fix block pull feature that was broken in refactor [\#13](https://github.com/niolabs/nio-cli/pull/13) ([hansmosh](https://github.com/hansmosh))
+- pip installs from requirements.txt [\#11](https://github.com/niolabs/nio-cli/pull/11) ([hansmosh](https://github.com/hansmosh))
+- Replace config files with flag options [\#8](https://github.com/niolabs/nio-cli/pull/8) ([hansmosh](https://github.com/hansmosh))
+- Merge in features from neutralio/scripts/nio-add-blocks [\#5](https://github.com/niolabs/nio-cli/pull/5) ([hansmosh](https://github.com/hansmosh))
+- Adds install\_requirements for python modules prettytable and requests [\#3](https://github.com/niolabs/nio-cli/pull/3) ([hansmosh](https://github.com/hansmosh))
+- Feature/nio instance [\#1](https://github.com/niolabs/nio-cli/pull/1) ([oleiman](https://github.com/oleiman))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## [0.5.5](https://github.com/niolabs/nio-cli/tree/0.5.5) (2018-03-15)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.4...0.5.5)
 
-**Merged pull requests:**
+**Implemented enhancements:**
 
 - nio new command searches project template for requirements.txt and installs libraries [\#87](https://github.com/niolabs/nio-cli/pull/87) ([cowleyk](https://github.com/cowleyk))
+
+**Merged pull requests:**
+
 - Add optional SSL cert generation and secure instance configuration [\#73](https://github.com/niolabs/nio-cli/pull/73) ([nioJake](https://github.com/nioJake))
 
 ## [0.5.4](https://github.com/niolabs/nio-cli/tree/0.5.4) (2018-02-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Change Log
 
+## [Unreleased](https://github.com/niolabs/nio-cli/tree/HEAD)
+
+[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.5...HEAD)
+
+**Added features:**
+
+- Nio 1055 id prep [\#88](https://github.com/niolabs/nio-cli/pull/88) ([tlugger](https://github.com/tlugger))
+
 ## [0.5.5](https://github.com/niolabs/nio-cli/tree/0.5.5) (2018-03-15)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.4...0.5.5)
 
-**Implemented enhancements:**
+**Added features:**
 
 - nio new command searches project template for requirements.txt and installs libraries [\#87](https://github.com/niolabs/nio-cli/pull/87) ([cowleyk](https://github.com/cowleyk))
 - Add optional SSL cert generation and secure instance configuration [\#73](https://github.com/niolabs/nio-cli/pull/73) ([nioJake](https://github.com/nioJake))
@@ -11,18 +19,8 @@
 ## [0.5.4](https://github.com/niolabs/nio-cli/tree/0.5.4) (2018-02-05)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.3...0.5.4)
 
-**Closed issues:**
+**Added features:**
 
-- missing pep8 requirement [\#75](https://github.com/niolabs/nio-cli/issues/75)
-- requirements for testing [\#74](https://github.com/niolabs/nio-cli/issues/74)
-- Link to docs in --help [\#17](https://github.com/niolabs/nio-cli/issues/17)
-
-**Merged pull requests:**
-
-- PK -\> Pubkeeper logging changes [\#82](https://github.com/niolabs/nio-cli/pull/82) ([tlugger](https://github.com/tlugger))
-- add dev requirements close \#74 [\#81](https://github.com/niolabs/nio-cli/pull/81) ([tyoungNIO](https://github.com/tyoungNIO))
-- Pep8 req close \#75 [\#80](https://github.com/niolabs/nio-cli/pull/80) ([tyoungNIO](https://github.com/tyoungNIO))
-- remove dot in nio [\#79](https://github.com/niolabs/nio-cli/pull/79) ([jennyknuth](https://github.com/jennyknuth))
 - add docs link to help close \#17 [\#78](https://github.com/niolabs/nio-cli/pull/78) ([tyoungNIO](https://github.com/tyoungNIO))
 
 ## [0.5.3](https://github.com/niolabs/nio-cli/tree/0.5.3) (2018-01-29)
@@ -32,24 +30,17 @@
 
 - close tmp file before rename [\#76](https://github.com/niolabs/nio-cli/pull/76) ([tyoungNIO](https://github.com/tyoungNIO))
 
-**Closed issues:**
-
-- nio server eats up 100% of CPU [\#24](https://github.com/niolabs/nio-cli/issues/24)
-- Update blocks should not reinitialize the submodules [\#23](https://github.com/niolabs/nio-cli/issues/23)
-- Server action should have a project location param [\#20](https://github.com/niolabs/nio-cli/issues/20)
-- Use pynio for nio api calls [\#4](https://github.com/niolabs/nio-cli/issues/4)
-
 ## [0.5.2](https://github.com/niolabs/nio-cli/tree/0.5.2) (2018-01-26)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.1...0.5.2)
 
-**Merged pull requests:**
+**Added features:**
 
 - config for nio.conf user defined [\#72](https://github.com/niolabs/nio-cli/pull/72) ([tlugger](https://github.com/tlugger))
 
 ## [0.5.1](https://github.com/niolabs/nio-cli/tree/0.5.1) (2018-01-24)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.0...0.5.1)
 
-**Implemented enhancements:**
+**Added features:**
 
 - refactor configure to not use sed [\#71](https://github.com/niolabs/nio-cli/pull/71) ([tlugger](https://github.com/tlugger))
 - fix niolabs and cli docs links [\#70](https://github.com/niolabs/nio-cli/pull/70) ([ssclay](https://github.com/ssclay))
@@ -57,146 +48,15 @@
 **Fixed bugs:**
 
 - refactor configure to not use sed [\#71](https://github.com/niolabs/nio-cli/pull/71) ([tlugger](https://github.com/tlugger))
-
-**Merged pull requests:**
-
-- Add seperator between blocks in buildreadme [\#69](https://github.com/niolabs/nio-cli/pull/69) ([hansmosh](https://github.com/hansmosh))
 - Handle failed git clone on 'nio new' [\#68](https://github.com/niolabs/nio-cli/pull/68) ([hansmosh](https://github.com/hansmosh))
-- Update install\_requires [\#67](https://github.com/niolabs/nio-cli/pull/67) ([hansmosh](https://github.com/hansmosh))
 
 ## [0.5.0](https://github.com/niolabs/nio-cli/tree/0.5.0) (2018-01-05)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.4...0.5.0)
 
-**Implemented enhancements:**
+**Added features:**
 
 - Config project [\#66](https://github.com/niolabs/nio-cli/pull/66) ([tlugger](https://github.com/tlugger))
 - Launch items [\#65](https://github.com/niolabs/nio-cli/pull/65) ([tlugger](https://github.com/tlugger))
-
-## [0.4.4](https://github.com/niolabs/nio-cli/tree/0.4.4) (2018-01-05)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.3...0.4.4)
-
-**Merged pull requests:**
-
-- command cleanup [\#64](https://github.com/niolabs/nio-cli/pull/64) ([tlugger](https://github.com/tlugger))
-- nio\_run -\> niod [\#63](https://github.com/niolabs/nio-cli/pull/63) ([tlugger](https://github.com/tlugger))
-
-## [0.4.3](https://github.com/niolabs/nio-cli/tree/0.4.3) (2018-01-03)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.2...0.4.3)
-
-**Merged pull requests:**
-
-- :sparkles: Buildspec command adds categories to each block [\#61](https://github.com/niolabs/nio-cli/pull/61) ([cowleyk](https://github.com/cowleyk))
-
-## [0.4.2](https://github.com/niolabs/nio-cli/tree/0.4.2) (2017-10-23)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.1...0.4.2)
-
-**Closed issues:**
-
-- Use git:// for git dependent commmands [\#60](https://github.com/niolabs/nio-cli/issues/60)
-
-**Merged pull requests:**
-
-- niolabs and git command updates [\#59](https://github.com/niolabs/nio-cli/pull/59) ([tlugger](https://github.com/tlugger))
-- Support multiple git remote formats for buildrelease [\#58](https://github.com/niolabs/nio-cli/pull/58) ([hansmosh](https://github.com/hansmosh))
-- Handle version [\#57](https://github.com/niolabs/nio-cli/pull/57) ([cowleyk](https://github.com/cowleyk))
-- Don't require niocore for all commands [\#55](https://github.com/niolabs/nio-cli/pull/55) ([hansmosh](https://github.com/hansmosh))
-- Update release for term/gen blocks [\#54](https://github.com/niolabs/nio-cli/pull/54) ([cowleyk](https://github.com/cowleyk))
-- Import Base rather than Block [\#53](https://github.com/niolabs/nio-cli/pull/53) ([cowleyk](https://github.com/cowleyk))
-- Populate proper inputs/outputs from block [\#52](https://github.com/niolabs/nio-cli/pull/52) ([cowleyk](https://github.com/cowleyk))
-- Blockcheck BLK-290 [\#51](https://github.com/niolabs/nio-cli/pull/51) ([cowleyk](https://github.com/cowleyk))
-- Do not check for exception in version property [\#50](https://github.com/niolabs/nio-cli/pull/50) ([dorzel](https://github.com/dorzel))
-- Use https github url format in buildrelease command [\#49](https://github.com/niolabs/nio-cli/pull/49) ([dorzel](https://github.com/dorzel))
-- Add "None" to README for blank section [\#48](https://github.com/niolabs/nio-cli/pull/48) ([kyliedale](https://github.com/kyliedale))
-- buildreadme commands supports newer spec schema [\#45](https://github.com/niolabs/nio-cli/pull/45) ([hansmosh](https://github.com/hansmosh))
-- Auto populate commands key [\#44](https://github.com/niolabs/nio-cli/pull/44) ([cowleyk](https://github.com/cowleyk))
-- Alphabetize blocks [\#43](https://github.com/niolabs/nio-cli/pull/43) ([cowleyk](https://github.com/cowleyk))
-- Buildrelease Command [\#42](https://github.com/niolabs/nio-cli/pull/42) ([dorzel](https://github.com/dorzel))
-
-## [0.4.1](https://github.com/niolabs/nio-cli/tree/0.4.1) (2017-08-04)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.4...0.4.1)
-
-## [0.3.4](https://github.com/niolabs/nio-cli/tree/0.3.4) (2017-08-04)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.3...0.3.4)
-
-**Closed issues:**
-
-- All binary executable to be configurable for `nio server` [\#27](https://github.com/niolabs/nio-cli/issues/27)
-
-**Merged pull requests:**
-
-- Keys of properties dict are the variable name and include a title key [\#40](https://github.com/niolabs/nio-cli/pull/40) ([cowleyk](https://github.com/cowleyk))
-- Newblock command BLK-264 [\#39](https://github.com/niolabs/nio-cli/pull/39) ([cowleyk](https://github.com/cowleyk))
-- New project inits repo after clone BLK-265 [\#36](https://github.com/niolabs/nio-cli/pull/36) ([hansmosh](https://github.com/hansmosh))
-- Add buildreadme command BLK-274 [\#35](https://github.com/niolabs/nio-cli/pull/35) ([hansmosh](https://github.com/hansmosh))
-- Specjson script BLK-273 [\#34](https://github.com/niolabs/nio-cli/pull/34) ([hansmosh](https://github.com/hansmosh))
-- Refactor and improve unit tests BLK-267 [\#33](https://github.com/niolabs/nio-cli/pull/33) ([hansmosh](https://github.com/hansmosh))
-- Update config command [\#32](https://github.com/niolabs/nio-cli/pull/32) ([nioJake](https://github.com/nioJake))
-- Add clone command [\#31](https://github.com/niolabs/nio-cli/pull/31) ([nioJake](https://github.com/nioJake))
-- Make Server Command Configurable [\#30](https://github.com/niolabs/nio-cli/pull/30) ([dorzel](https://github.com/dorzel))
-
-## [0.3.3](https://github.com/niolabs/nio-cli/tree/0.3.3) (2017-04-17)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.3.1...0.3.3)
-
-**Closed issues:**
-
-- Don't default IP address to 0.0.0.0 [\#28](https://github.com/niolabs/nio-cli/issues/28)
-
-**Merged pull requests:**
-
-- Update default IP Address [\#29](https://github.com/niolabs/nio-cli/pull/29) ([mattdodge](https://github.com/mattdodge))
-
-## [0.3.1](https://github.com/niolabs/nio-cli/tree/0.3.1) (2016-06-16)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/v0.3.1...0.3.1)
-
-## [v0.3.1](https://github.com/niolabs/nio-cli/tree/v0.3.1) (2016-06-16)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/v0.3.0...v0.3.1)
-
-**Closed issues:**
-
-- For nio 2.0 start nio with `nio\_full` instead of `run\_nio` [\#26](https://github.com/niolabs/nio-cli/issues/26)
-
-## [v0.3.0](https://github.com/niolabs/nio-cli/tree/v0.3.0) (2016-06-16)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.2.0b1...v0.3.0)
-
-## [0.2.0b1](https://github.com/niolabs/nio-cli/tree/0.2.0b1) (2016-03-09)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.1.14...0.2.0b1)
-
-**Merged pull requests:**
-
-- Checkout appropriate project version tag on new project [\#25](https://github.com/niolabs/nio-cli/pull/25) ([hansmosh](https://github.com/hansmosh))
-
-## [0.1.14](https://github.com/niolabs/nio-cli/tree/0.1.14) (2015-06-04)
-[Full Changelog](https://github.com/niolabs/nio-cli/compare/0.1.13...0.1.14)
-
-**Closed issues:**
-
-- nio server [\#9](https://github.com/niolabs/nio-cli/issues/9)
-
-**Merged pull requests:**
-
-- Making recursive install a classmethod [\#22](https://github.com/niolabs/nio-cli/pull/22) ([mattdodge](https://github.com/mattdodge))
-
-## [0.1.13](https://github.com/niolabs/nio-cli/tree/0.1.13) (2015-05-26)
-**Closed issues:**
-
-- Install from requirements files in submodules [\#12](https://github.com/niolabs/nio-cli/issues/12)
-- Install block dependencies when adding blocks [\#10](https://github.com/niolabs/nio-cli/issues/10)
-- Use only one config file [\#7](https://github.com/niolabs/nio-cli/issues/7)
-
-**Merged pull requests:**
-
-- Keeping version in \_\_init\_\_.py file [\#21](https://github.com/niolabs/nio-cli/pull/21) ([mattdodge](https://github.com/mattdodge))
-- Add background flag to server action [\#19](https://github.com/niolabs/nio-cli/pull/19) ([hansmosh](https://github.com/hansmosh))
-- Update repo for pypi [\#18](https://github.com/niolabs/nio-cli/pull/18) ([hansmosh](https://github.com/hansmosh))
-- Recurisvely install requirements from block repos [\#16](https://github.com/niolabs/nio-cli/pull/16) ([hansmosh](https://github.com/hansmosh))
-- Add 'nio server' command [\#15](https://github.com/niolabs/nio-cli/pull/15) ([hansmosh](https://github.com/hansmosh))
-- Read NIOHOST and NIOPORT from environements vars. Close \#7 [\#14](https://github.com/niolabs/nio-cli/pull/14) ([hansmosh](https://github.com/hansmosh))
-- Fix block pull feature that was broken in refactor [\#13](https://github.com/niolabs/nio-cli/pull/13) ([hansmosh](https://github.com/hansmosh))
-- pip installs from requirements.txt [\#11](https://github.com/niolabs/nio-cli/pull/11) ([hansmosh](https://github.com/hansmosh))
-- Replace config files with flag options [\#8](https://github.com/niolabs/nio-cli/pull/8) ([hansmosh](https://github.com/hansmosh))
-- Merge in features from neutralio/scripts/nio-add-blocks [\#5](https://github.com/niolabs/nio-cli/pull/5) ([hansmosh](https://github.com/hansmosh))
-- Adds install\_requirements for python modules prettytable and requests [\#3](https://github.com/niolabs/nio-cli/pull/3) ([hansmosh](https://github.com/hansmosh))
-- Feature/nio instance [\#1](https://github.com/niolabs/nio-cli/pull/1) ([oleiman](https://github.com/oleiman))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 **Implemented enhancements:**
 
 - nio new command searches project template for requirements.txt and installs libraries [\#87](https://github.com/niolabs/nio-cli/pull/87) ([cowleyk](https://github.com/cowleyk))
-
-**Merged pull requests:**
-
 - Add optional SSL cert generation and secure instance configuration [\#73](https://github.com/niolabs/nio-cli/pull/73) ([nioJake](https://github.com/nioJake))
 
 ## [0.5.4](https://github.com/niolabs/nio-cli/tree/0.5.4) (2018-02-05)
@@ -31,16 +28,16 @@
 ## [0.5.3](https://github.com/niolabs/nio-cli/tree/0.5.3) (2018-01-29)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.2...0.5.3)
 
+**Fixed bugs:**
+
+- close tmp file before rename [\#76](https://github.com/niolabs/nio-cli/pull/76) ([tyoungNIO](https://github.com/tyoungNIO))
+
 **Closed issues:**
 
 - nio server eats up 100% of CPU [\#24](https://github.com/niolabs/nio-cli/issues/24)
 - Update blocks should not reinitialize the submodules [\#23](https://github.com/niolabs/nio-cli/issues/23)
 - Server action should have a project location param [\#20](https://github.com/niolabs/nio-cli/issues/20)
 - Use pynio for nio api calls [\#4](https://github.com/niolabs/nio-cli/issues/4)
-
-**Merged pull requests:**
-
-- close tmp file before rename [\#76](https://github.com/niolabs/nio-cli/pull/76) ([tyoungNIO](https://github.com/tyoungNIO))
 
 ## [0.5.2](https://github.com/niolabs/nio-cli/tree/0.5.2) (2018-01-26)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.1...0.5.2)
@@ -52,10 +49,17 @@
 ## [0.5.1](https://github.com/niolabs/nio-cli/tree/0.5.1) (2018-01-24)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.5.0...0.5.1)
 
-**Merged pull requests:**
+**Implemented enhancements:**
 
 - refactor configure to not use sed [\#71](https://github.com/niolabs/nio-cli/pull/71) ([tlugger](https://github.com/tlugger))
 - fix niolabs and cli docs links [\#70](https://github.com/niolabs/nio-cli/pull/70) ([ssclay](https://github.com/ssclay))
+
+**Fixed bugs:**
+
+- refactor configure to not use sed [\#71](https://github.com/niolabs/nio-cli/pull/71) ([tlugger](https://github.com/tlugger))
+
+**Merged pull requests:**
+
 - Add seperator between blocks in buildreadme [\#69](https://github.com/niolabs/nio-cli/pull/69) ([hansmosh](https://github.com/hansmosh))
 - Handle failed git clone on 'nio new' [\#68](https://github.com/niolabs/nio-cli/pull/68) ([hansmosh](https://github.com/hansmosh))
 - Update install\_requires [\#67](https://github.com/niolabs/nio-cli/pull/67) ([hansmosh](https://github.com/hansmosh))
@@ -63,7 +67,7 @@
 ## [0.5.0](https://github.com/niolabs/nio-cli/tree/0.5.0) (2018-01-05)
 [Full Changelog](https://github.com/niolabs/nio-cli/compare/0.4.4...0.5.0)
 
-**Merged pull requests:**
+**Implemented enhancements:**
 
 - Config project [\#66](https://github.com/niolabs/nio-cli/pull/66) ([tlugger](https://github.com/tlugger))
 - Launch items [\#65](https://github.com/niolabs/nio-cli/pull/65) ([tlugger](https://github.com/tlugger))

--- a/changelog_how_to.md
+++ b/changelog_how_to.md
@@ -3,7 +3,7 @@
 The changelog is visible at docs.n.io/cli/changelog.html. Update the changelog after each release.
 To generate the changelog from the PR history, use the command-line tool github-changelog-generator.
 
-1. To install the github-changelog-generator, follow the directions here: [https://github.com/skywinder/github-changelog-generator](https://github.com/skywinder/github-changelog-generator) 
+1. To install the github-changelog-generator, follow the directions here: [https://github.com/skywinder/github-changelog-generator](https://github.com/skywinder/github-changelog-generator)
 
 2. Label any relevant PRs on GitHub with one or more of the following labels: bug, enhancement, deprecated, removed, security
 
@@ -23,4 +23,4 @@ To generate the changelog from the PR history, use the command-line tool github-
   ```
   and then repeat the command in step 3 above to generate your CHANGELOG.md.
 
-4. You can then add the most recent changes to the release notes.
+4. You can then copy and paste the most recent changes into the release notes.

--- a/changelog_how_to.md
+++ b/changelog_how_to.md
@@ -1,0 +1,26 @@
+# Auto-generate the CHANGELOG.md
+
+The changelog is visible at docs.n.io/cli/changelog.html. Update the changelog after each release.
+To generate the changelog from the PR history, use the command-line tool github-changelog-generator.
+
+1. To install the github-changelog-generator, follow the directions here: [https://github.com/skywinder/github-changelog-generator](https://github.com/skywinder/github-changelog-generator) 
+
+2. Label any relevant PRs on GitHub with one or more of the following labels: bug, enhancement, deprecated, removed, security
+
+3. Generate the CHANGELOG.md with the command:
+
+  ```bash
+  github_changelog_generator niolabs/nio-cli
+  ```
+
+  If you get an API rate-limit error, you need to get a token to make authenticated requests to the GitHub API.
+
+  Simply [generate a token here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token) with only "repo" scope permissions selected.
+
+  Copy your token and type
+  ```bash
+  export CHANGELOG_GITHUB_TOKEN="«your-40-digit-github-token»"
+  ```
+  and then repeat the command in step 3 above to generate your CHANGELOG.md.
+
+4. You can then add the most recent changes to the release notes.

--- a/changelog_how_to.md
+++ b/changelog_how_to.md
@@ -5,7 +5,7 @@ To generate the changelog from the PR history, use the command-line tool github-
 
 1. To install the github-changelog-generator, follow the directions here: [https://github.com/skywinder/github-changelog-generator](https://github.com/skywinder/github-changelog-generator)
 
-2. Label any relevant PRs on GitHub with one or more of the following labels: bug, enhancement, deprecated, removed, security
+2. Double check that any relevant PRs on GitHub are correctly labeled with one or more of the following labels: bug, enhancement, deprecated, removed, security. These are the PRs that will show up in the changelog.
 
 3. Generate the CHANGELOG.md with the command:
 


### PR DESCRIPTION
To add the changelog to the docs, we need a CHANGELOG.md file. This PR pilots a method to autogenerate this file with each new release. 