### PR TITLE
Silently fail on git commit errors

### DIFF
--- a/nio_cli/commands/new.py
+++ b/nio_cli/commands/new.py
@@ -28,7 +28,7 @@ class New(Base):
         reinit_repo = (
             'cd ./{} '
             '&& git remote remove origin '
-            '&& git commit --amend --reset-author -m "Initial commit"'
+            '&& git commit --amend --reset-author -m "Initial commit" > /dev/null 2>&1'
         ).format(self._name)
         subprocess.call(clone, shell=True)
         if not os.path.isdir(self._name):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(call.call_args_list[2][0][0], (
             'cd ./project '
             '&& git remote remove origin '
-            '&& git commit --amend --reset-author -m "Initial commit"'
+            '&& git commit --amend --reset-author -m "Initial commit" > /dev/null 2>&1'
         ))
 
     def test_new_command_template(self):
@@ -97,7 +97,7 @@ class TestCLI(unittest.TestCase):
                 self.assertEqual(call.call_args_list[2][0][0], (
                     'cd ./project '
                     '&& git remote remove origin '
-                    '&& git commit --amend --reset-author -m "Initial commit"'
+                    '&& git commit --amend --reset-author -m "Initial commit" > /dev/null 2>&1'
                 ))
                 patch_pip_main.assert_called_once_with(
                     ['install', '-r', 'join'])


### PR DESCRIPTION
If the "Initial commit" command of `nio new` stops with a `** Please tell me who you are` error, fail silently. This allows environments without GitHub configured to continue without clearing the old commit history. 