### PR TITLE
Hide id in blockspec

### DIFF
--- a/nio_cli/commands/buildspec.py
+++ b/nio_cli/commands/buildspec.py
@@ -111,7 +111,7 @@ class BuildSpec(Base):
         properties_spec = {}
         properties = block.get_description()["properties"]
         for k, property in properties.items():
-            if k in ["type", "name", "version", "log_level"]:
+            if k in ["id", "type", "name", "version", "log_level"]:
                 continue
             property_spec = {}
             property_spec["title"] = property["title"]


### PR DESCRIPTION
When following the documentation and running `nio buildspec <block repo name>` a new `id` property gets generated. We will want to hide `id` in the `spec.json`