### PR TITLE
remove repo readme before renaming block readme

### DIFF
--- a/nio_cli/commands/newblock.py
+++ b/nio_cli/commands/newblock.py
@@ -25,6 +25,7 @@ class NewBlock(Base):
                                "{0}_block.py".format(self._block)))
 
         # rename readme
+        os.remove(os.path.join(block_root_path, "README.md"))
         os.rename(os.path.join(block_root_path, "BLOCK_README.md"),
                   os.path.join(block_root_path, "README.md"))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -496,6 +496,7 @@ class TestCLI(unittest.TestCase):
                 mock_file.return_value.write.call_args_list[0][0][0],
                 'YabaDaba ..example_block TestYabaDaba')
             # assert calls to rename block files
+            self.assertEqual(os_mock.remove.call_count, 1)
             self.assertEqual(os_mock.rename.call_count, 3)
 
     def test_blockcheck_command(self):


### PR DESCRIPTION
```
C:\Users\Tom\nio\projects\testo>nio newblock thisistheblockthatneverends
Cloning into 'thisistheblockthatneverends'...
remote: Counting objects: 11, done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 11 (delta 0), reused 6 (delta 0), pack-reused 0
Receiving objects: 100% (11/11), done.
Traceback (most recent call last):
  File "C:\Users\Tom\AppData\Local\Programs\Python\Python36\Scripts\nio-script.py", line 11, in <module>
    load_entry_point('nio-cli', 'console_scripts', 'nio')()
  File "c:\users\tom\nio\nio-cli\nio_cli\cli.py", line 65, in main
    command(options).run()
  File "c:\users\tom\nio\nio-cli\nio_cli\commands\newblock.py", line 29, in run
    os.path.join(block_root_path, "README.md"))
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\Users\\Tom\\nio\\projects\
\testo\\thisistheblockthatneverends\\BLOCK_README.md' -> 'C:\\Users\\Tom\\nio\\projects\\testo\\thisistheblocktha
tneverends\\README.md'
```