### PR TITLE
Add block url to etc/blocks.cfg on nio add

### DIFF
--- a/nio_cli/commands/add.py
+++ b/nio_cli/commands/add.py
@@ -1,4 +1,5 @@
 import os
+import json
 import subprocess
 import sys
 
@@ -20,6 +21,8 @@ class Add(Base):
             subprocess.call(
                 submodule.format('nio-blocks', block, self._project, 'blocks', block),
                 shell=True)
+            # Add block url to etc/blocks.cfg
+            self._add_to_blocks_cfg(block)
         # Initialize all submodules
         subprocess.call("git submodule update --init --recursive", shell=True)
         # Upgrade blocks if requested
@@ -36,6 +39,26 @@ class Add(Base):
                     if file_name == 'requirements.txt':
                         reqs = os.path.join(root, file_name)
                         subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', reqs])
+
+    def _add_to_blocks_cfg(self, block):
+        blocks_location = "{}/etc/blocks.cfg".format(self._project)
+        if os.path.isfile(blocks_location):
+            with open(blocks_location, 'r') as f:
+                blocks = json.load(f)
+        else:
+            blocks = { "blocks": [] }
+
+        # Create new block entry and add it to blocks list
+        new_block = {
+            "branch": None,
+            "path": None,
+            "tag": None,
+            "url": "git://github.com/nio-blocks/{}.git".format(block)
+        }
+        blocks['blocks'].append(new_block)
+
+        with open(blocks_location, 'w+') as f:
+            json.dump(blocks, f, indent=4, separators=(',', ':'))
 
     def _upgrade_block(self, block):
         checkout = "cd {}/{}/{} && git checkout {}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,7 +129,12 @@ class TestCLI(unittest.TestCase):
 
     def test_add_command(self):
         """Clone specified blocks as submodules"""
-        with patch('nio_cli.commands.add.subprocess.call') as call:
+        with patch('nio_cli.commands.add.os') as mock_os, \
+            patch('nio_cli.commands.add.json') as mock_json, \
+            patch('builtins.open') as mock_open, \
+            patch('nio_cli.commands.add.subprocess.call') as call:
+            mock_os.isfile.return_value = True
+
             self._main('add', **{
                 '<block-repo>': ['block1'],
                 '--project': '.'
@@ -141,6 +146,7 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(call.call_args_list[1][0][0], (
                 'git submodule update --init --recursive'
             ))
+            self.assertTrue(mock_open.call_count == 2)
 
     @responses.activate
     def test_list_command(self):


### PR DESCRIPTION
Needed for block management epic. This adds a new entry for all blocks added using `nio add` so they are returned under the `/project/blockTypes` endpoint