### PR TITLE
NIO 1129

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+Any additional info regarding implementation and how to replicate locally
+
+## JIRA Issue (Optional)
+[NIO-xyz](https://neutralio.atlassian.net/browse/NIO-xyz)
+
+## Todos
+- [ ] Tested and working locally
+- [ ] Unit Tests
+- [ ] Updated [documentation](https://github.com/niolabs/docs)
+- [ ] Add a label to the PR

--- a/nio_cli/cli.py
+++ b/nio_cli/cli.py
@@ -2,8 +2,8 @@
 nio
 
 Usage:
-  nio new <project-name> [(--template <template> | -t <template>) --pubkeeper-hostname=HOST --pubkeeper-token=TOKEN]
   nio newblock <block-name>
+  nio [options] new <project-name> [(--template <template> | -t <template>) --pubkeeper-hostname=HOST --pubkeeper-token=TOKEN --ssl]
   nio [options] add <block-repo>... [(--upgrade | -u)]
   nio [options] (list | ls) services
   nio [options] (list | ls) blocks
@@ -23,8 +23,8 @@ Usage:
   nio --version
 
 Options:
-  -p PORT --port=PORT               Specify nio port [default: 8181].
-  -i IP --ip=IP                     Specify nio ip address [default: 127.0.0.1].
+  -p PORT --port=PORT               Specify nio port.
+  -i IP --ip=IP                     Specify nio ip address.
   --username=USERNAME               Specify username [default: Admin].
   --password=PASSWORD               Specify password [default: Admin].
   --project=PROJECT                 Specify project directory [default: .].

--- a/nio_cli/commands/base.py
+++ b/nio_cli/commands/base.py
@@ -7,8 +7,13 @@ class Base(object):
         self.options = options
         self.args = args
         self.kwargs = kwargs
-        self._base_url = "http://{}:{}/{{}}".format(self.options['--ip'],
-                                                    self.options['--port'])
+        self._ip = self.options['--ip']\
+            if self.options['--ip'] is not None\
+            else '0.0.0.0'
+        self._port = self.options['--port']\
+            if self.options['--port'] is not None\
+            else '8181'
+        self._base_url = "http://{}:{}/{{}}".format(self._ip, self._port)
         # default to Admin/Admin
         self._auth = ('Admin', 'Admin')
 

--- a/nio_cli/commands/config.py
+++ b/nio_cli/commands/config.py
@@ -27,7 +27,12 @@ class Config(Base):
     def run(self):
         if self._resource == 'project':
             config_project(name=self.options['--project'],
+                           pubkeeper_hostname=self.options.get('pubkeeper-hostname'),
+                           pubkeeper_token=self.options.get('pubkeeper-token'),
                            username=self.options['--username'],
-                           password=self.options['--password'])
+                           password=self.options['--password'],
+                           ssl=self.options.get('--ssl'),
+                           niohost=self.options['--ip'],
+                           nioport=self.options['--port'])
         else:
             self.config_block_or_service()

--- a/nio_cli/commands/new.py
+++ b/nio_cli/commands/new.py
@@ -15,6 +15,9 @@ class New(Base):
         self._pubkeeper_token = self.options.get('--pubkeeper-token')
         self._username = self.options['--username']
         self._password = self.options['--password']
+        self._ssl = self.options.get('--ssl')
+        self._niohost = self.options.get('--ip')
+        self._nioport = self.options.get('--port')
 
     def run(self):
         repo = 'git://github.com/niolabs/project_template.git'
@@ -43,9 +46,14 @@ class New(Base):
             for file_name in files:
                 if file_name == 'requirements.txt':
                     reqs = os.path.join(root, file_name)
-                    subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', reqs, '--user'])
-        config_project(
-            self._name, self._pubkeeper_hostname, self._pubkeeper_token,
-            self._username, self._password
+                    subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', reqs])
+        config_project(name=self._name,
+                       pubkeeper_hostname=self._pubkeeper_hostname,
+                       pubkeeper_token=self._pubkeeper_token,
+                       username=self._username,
+                       password=self._password,
+                       ssl=self._ssl,
+                       niohost=self._niohost,
+                       nioport=self._nioport
         )
         subprocess.call(reinit_repo, shell=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,7 +58,14 @@ class TestCLI(unittest.TestCase):
             '--username': 'user',
             '--password': 'pwd'
         })
-        config.assert_called_once_with('project', None, None, 'user', 'pwd')
+        config.assert_called_once_with(name='project',
+                                       niohost='127.0.0.1',
+                                       nioport='8181',
+                                       pubkeeper_hostname=None,
+                                       pubkeeper_token=None,
+                                       username='user',
+                                       password='pwd',
+                                       ssl=None)
         self.assertEqual(call.call_args_list[0][0][0], (
             'git clone --depth=1 '
             'git://github.com/niolabs/project_template.git project'
@@ -95,8 +102,14 @@ class TestCLI(unittest.TestCase):
                     '--username': 'user',
                     '--password': 'pwd'
                 })
-                config.assert_called_once_with('project', 'pkhost', 'pktoken',
-                                               'user', 'pwd')
+                config.assert_called_once_with(name='project',
+                                               niohost='127.0.0.1',
+                                               nioport='8181',
+                                               pubkeeper_hostname='pkhost',
+                                               pubkeeper_token='pktoken',
+                                               username='user',
+                                               password='pwd',
+                                               ssl=None)
                 self.assertEqual(call.call_args_list[0][0][0], (
                     'git clone --depth=1 '
                     'git://github.com/niolabs/my_template.git project'
@@ -106,7 +119,7 @@ class TestCLI(unittest.TestCase):
                     '&& git submodule update --init --recursive'
                 ))
                 self.assertEqual(call.call_args_list[2][0][0], (
-                    [sys.executable, '-m', 'pip', 'install', '-r', 'join', '--user']
+                    [sys.executable, '-m', 'pip', 'install', '-r', 'join']
                 ))
                 self.assertEqual(call.call_args_list[3][0][0], (
                     'cd ./project '


### PR DESCRIPTION
## Description
This PR improves the CLI flow for `nio new` and `nio config` commands. Rather than several on screen prompts, these commands now accept several flags that will auto set things like pubkeeper credentials, user authentication, ip and port, and creation of an ssl cert.

Removed the `--user` flag from the pip install command on `nio new` to prevent the errors that appear in the console when running in a virtual environment.

IP and PORT default values have been remove from docopt and are now defaulted to `0.0.0.0` and `8181` in the base command class for commands that interact with the nio api. This has been done to prevent a configured ip or port from being set back to the default value on a `nio config`.

Finally, a PR template has been added following the same format as this very description!

## JIRA Issue (Optional)
[NIO-1129](https://neutralio.atlassian.net/browse/NIO-1129)

## Todos
- [X] Tested and working locally
- [X] Unit Tests
- [X] Updated [documentation](https://github.com/niolabs/docs)
- [X] Add a label to the PR