### PR TITLE
fix options reference to pk host/port in config

### DIFF
--- a/nio_cli/commands/config.py
+++ b/nio_cli/commands/config.py
@@ -27,8 +27,8 @@ class Config(Base):
     def run(self):
         if self._resource == 'project':
             config_project(name=self.options['--project'],
-                           pubkeeper_hostname=self.options.get('pubkeeper-hostname'),
-                           pubkeeper_token=self.options.get('pubkeeper-token'),
+                           pubkeeper_hostname=self.options.get('--pubkeeper-hostname'),
+                           pubkeeper_token=self.options.get('--pubkeeper-token'),
                            username=self.options['--username'],
                            password=self.options['--password'],
                            ssl=self.options.get('--ssl'),


### PR DESCRIPTION
## Description
Missing the `--` to reference pubkeeper options in `nio config`

## JIRA Issue (Optional)
[NIO-1129](https://neutralio.atlassian.net/browse/NIO-1129)

## Todos
- [x] Tested and working locally
- [x] Add a label to the PR