### PR TITLE
Use correct localhost ip

### DIFF
--- a/nio_cli/commands/base.py
+++ b/nio_cli/commands/base.py
@@ -9,7 +9,7 @@ class Base(object):
         self.kwargs = kwargs
         self._ip = self.options['--ip']\
             if self.options['--ip'] is not None\
-            else '0.0.0.0'
+            else '127.0.0.1'
         self._port = self.options['--port']\
             if self.options['--port'] is not None\
             else '8181'


### PR DESCRIPTION
## Description
Tom was having issues with the CLI using `0.0.0.0` as the default hostname. This should have been `127.0.0.1` but was mistakenly changed.

## Todos
- [X] Tested and working locally
- [X] Updated [documentation](https://github.com/niolabs/docs)
- [X] Add a label to the PR