### PR TITLE
Write cert matter as bytes

### DIFF
--- a/nio_cli/utils.py
+++ b/nio_cli/utils.py
@@ -77,10 +77,10 @@ def _config_ssl(name, conf_location):
         cert.set_pubkey(kp)
         cert.sign(kp, 'sha1')
 
-        open('{}/certificate.pem'.format(name), "wt").write(
-            str(crypto.dump_certificate(crypto.FILETYPE_PEM, cert)))
-        open('{}/private_key.pem'.format(name), "wt").write(
-            str(crypto.dump_privatekey(crypto.FILETYPE_PEM, kp)))
+        open('{}/certificate.pem'.format(name), "wb").write(
+            crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+        open('{}/private_key.pem'.format(name), "wb").write(
+            crypto.dump_privatekey(crypto.FILETYPE_PEM, kp))
 
         ssl_cert = '{}/{}/certificate.pem'.format(cwd, name)
         ssl_key = '{}/{}/private_key.pem'.format(cwd, name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,9 +56,9 @@ class TestConfigSSL(unittest.TestCase):
         self._run_config_ssl(user_input)
         self.assertEqual(self.mock_open.call_count, 3)
         self.assertEqual(
-            self.mock_open.call_args_list[0][0], ('./certificate.pem', 'wt'))
+            self.mock_open.call_args_list[0][0], ('./certificate.pem', 'wb'))
         self.assertEqual(
-            self.mock_open.call_args_list[1][0], ('./private_key.pem', 'wt'))
+            self.mock_open.call_args_list[1][0], ('./private_key.pem', 'wb'))
         self.assertEqual(
             self.mock_open.call_args_list[2][0], ('./nio.conf', 'r'))
         self.mock_os.remove.assert_called_once_with('./nio.conf')


### PR DESCRIPTION
Previously this was `str`-ing the bytes and writing certs and private keys that looked like this, causing nio to reject them
```
b'-----BEGIN CERTIFICATE-----\nMII...
```

Instead this will write the raw bytes to the file which makes the certs valid.