### PR TITLE
Use bcrypt hashing for user/pasword creation

### DIFF
--- a/nio_cli/utils.py
+++ b/nio_cli/utils.py
@@ -1,8 +1,8 @@
 import os
 import json
-from base64 import b64encode
 import re
 import tempfile
+from bcrypt import hashpw, gensalt
 
 def config_project(name='.', pubkeeper_hostname=None, pubkeeper_token=None,
                    username=None, password=None, ssl=False, niohost=None,
@@ -103,10 +103,6 @@ def _config_ssl(name, conf_location):
 
 
 def set_user(project_name, username, password):
-    # Return if user is not changed from default
-    if username == 'Admin' and password == 'Admin':
-        return
-
     # load users
     users_location = '{}/etc/users.json'.format(project_name)
     if os.path.isfile(users_location):
@@ -119,7 +115,7 @@ def set_user(project_name, username, password):
     if username and password:
         print('Adding user: {}'.format(username))
         users[username] = {
-            "password": _base64_encode(password)
+            "password": _hash_password(password)
         }
         # write it back
         with open(users_location, 'w+') as f:
@@ -145,11 +141,11 @@ def _set_permissions(project_name, username):
     with open(permission_location, 'w+') as f:
         json.dump(permissions, f, indent=4, separators=(',', ': '))
 
-def _base64_encode(s, encoding='ISO-8859-1'):
-    """Return the native string base64-encoded (as a native string)."""
+def _hash_password(s, encoding='ISO-8859-1'):
+    """Return the native string bcrypt hashed (as a native string)."""
     if isinstance(s, str):
-        b = s.encode(encoding)
+        pwd = s.encode(encoding)
     else:
-        b = s
-    b = b64encode(b)
-    return b.decode(encoding)
+        pwd = s
+    hashed = hashpw(pwd, gensalt())
+    return hashed.decode(encoding)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
     ],
     packages=find_packages(exclude=['docs', 'tests', 'tests.*']),
-    install_requires=['nio', 'requests', 'docopts', 'pycodestyle'],
+    install_requires=['nio', 'requests', 'docopts', 'pycodestyle', 'bcrypt'],
     tests_require=['pytest', 'pytest-cov', 'responses'],
     extras_require={'dev': ['responses']},
     cmdclass={'test': PyTest},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,12 +615,14 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(set_user_patch.call_args_list[0],
                              call('testing_project', 'user', 'pwd'))
 
-        from nio_cli.utils import set_user, _base64_encode, _set_permissions
+        from nio_cli.utils import set_user, _hash_password, _set_permissions
         with patch(set_user.__module__ + '.os') as mock_os, \
                 patch(set_user.__module__ + '.json') as mock_json, \
                 patch('builtins.open') as mock_open, \
+                patch('nio_cli.utils._hash_password') as mock_hash, \
                 patch('nio_cli.utils._set_permissions'):
             mock_os.path.isfile.return_value = True
+            mock_hash.return_value = "AdminPwdHash"
             mock_json.load.return_value = {"Admin": "AdminPwd"}
 
             username = "user1"
@@ -637,7 +639,7 @@ class TestCLI(unittest.TestCase):
             users, _ = mock_json.dump.call_args_list[0][0]
             self.assertIn(username, users)
             self.assertDictEqual(users[username],
-                                 {"password": _base64_encode(password)})
+                                 {"password": "AdminPwdHash"})
 
             _set_permissions('testing_project', username)
             # make sure we open permissions.json two times


### PR DESCRIPTION
## Description
When new users are created (either through `add_user`, `new`, or `config` with `--username` and `--password` flags passed) the password will be hashed using a bcrypt function. This password will be validated on newer versions of the nio basic secuirty module for all api requests.

## JIRA Issue (Optional)
[NIO-1175](https://neutralio.atlassian.net/browse/NIO-1175)

## Todos
- [X] Tested and working locally
- [X] Unit Tests
- [X] Updated [documentation](https://github.com/niolabs/docs)
- [X] Add a label to the PR