### PR TITLE
Ability to overwrite users on new

### DIFF
--- a/nio_cli/commands/new.py
+++ b/nio_cli/commands/new.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 from .base import Base
-from nio_cli.utils import config_project
+from nio_cli.utils import config_project, set_user
 
 
 class New(Base):
@@ -13,8 +13,8 @@ class New(Base):
         self._template = self.options.get('<template>')
         self._pubkeeper_hostname = self.options.get('--pubkeeper-hostname')
         self._pubkeeper_token = self.options.get('--pubkeeper-token')
-        self._username = self.options['--username']
-        self._password = self.options['--password']
+        self._username = self.options.get('--username')
+        self._password = self.options.get('--password')
         self._ssl = self.options.get('--ssl')
         self._niohost = self.options.get('--ip')
         self._nioport = self.options.get('--port')
@@ -48,11 +48,14 @@ class New(Base):
                     reqs = os.path.join(root, file_name)
                     subprocess.call(
                         [sys.executable, '-m', 'pip', 'install', '-r', reqs])
+
+        # Overwrite user credentials
+        if self._username and self._password:
+            set_user(self._name, self._username, self._password, True)
+
         config_project(name=self._name,
                        pubkeeper_hostname=self._pubkeeper_hostname,
                        pubkeeper_token=self._pubkeeper_token,
-                       username=self._username,
-                       password=self._password,
                        ssl=self._ssl,
                        niohost=self._niohost,
                        nioport=self._nioport

--- a/nio_cli/utils.py
+++ b/nio_cli/utils.py
@@ -120,14 +120,14 @@ def set_user(project_name, username, password, replace=False):
         # write it back
         with open(users_location, 'w+') as f:
             json.dump(users, f, indent=4, separators=(',', ': '))
-        _set_permissions(project_name, username)
+        _set_permissions(project_name, username, replace)
     else:
         print('Username cannot be empty')
 
-def _set_permissions(project_name, username):
+def _set_permissions(project_name, username, replace):
     # Add new user with admin level permission
     permission_location = '{}/etc/permissions.json'.format(project_name)
-    if os.path.isfile(permission_location):
+    if os.path.isfile(permission_location) and not replace:
         with open(permission_location, 'r') as f:
             permissions = json.load(f)
     else:

--- a/nio_cli/utils.py
+++ b/nio_cli/utils.py
@@ -102,10 +102,10 @@ def _config_ssl(name, conf_location):
     os.rename(tmp.name, conf_location)
 
 
-def set_user(project_name, username, password):
+def set_user(project_name, username, password, replace=False):
     # load users
     users_location = '{}/etc/users.json'.format(project_name)
-    if os.path.isfile(users_location):
+    if os.path.isfile(users_location) and not replace:
         with open(users_location, 'r') as f:
             users = json.load(f)
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,17 +54,54 @@ class TestCLI(unittest.TestCase):
             '<project-name>': 'project',
             '<template>': None,
             '--pubkeeper-hostname': None,
-            '--pubkeeper-token': None,
-            '--username': 'user',
-            '--password': 'pwd'
+            '--pubkeeper-token': None
         })
         config.assert_called_once_with(name='project',
                                        niohost='127.0.0.1',
                                        nioport='8181',
                                        pubkeeper_hostname=None,
                                        pubkeeper_token=None,
-                                       username='user',
-                                       password='pwd',
+                                       ssl=None)
+        self.assertEqual(call.call_args_list[0][0][0], (
+            'git clone '
+            'git://github.com/niolabs/project_template.git project'
+        ))
+        self.assertEqual(call.call_args_list[1][0][0], (
+            'cd ./project '
+            '&& git submodule update --init --recursive'
+        ))
+        self.assertEqual(call.call_args_list[2][0][0], (
+            'cd ./project '
+            '&& git remote remove origin '
+            '&& git commit --amend --reset-author --quiet -m "Initial commit"'
+        ))
+
+    def test_new_command_set_user(self):
+        """Clone the project template from GitHub"""
+        with patch('nio_cli.commands.new.os.path.isdir', return_value=True), \
+                patch('nio_cli.commands.new.subprocess.call') as call, \
+                patch('nio_cli.commands.new.set_user') as user, \
+                patch('nio_cli.commands.new.config_project') as config:
+            self._patched_new_command_set_user(call, user, config)
+
+    def _patched_new_command_set_user(self, call, user, config):
+        self._main('new', **{
+            '<project-name>': 'project',
+            '<template>': None,
+            '--pubkeeper-hostname': None,
+            '--pubkeeper-token': None,
+            '--username': 'new_user',
+            '--password': 'new_password'
+        })
+        user.assert_called_once_with('project',
+                                     'new_user',
+                                     'new_password',
+                                     True)
+        config.assert_called_once_with(name='project',
+                                       niohost='127.0.0.1',
+                                       nioport='8181',
+                                       pubkeeper_hostname=None,
+                                       pubkeeper_token=None,
                                        ssl=None)
         self.assertEqual(call.call_args_list[0][0][0], (
             'git clone '
@@ -98,17 +135,13 @@ class TestCLI(unittest.TestCase):
                     '<project-name>': 'project',
                     '<template>': 'my_template',
                     '--pubkeeper-hostname': 'pkhost',
-                    '--pubkeeper-token': 'pktoken',
-                    '--username': 'user',
-                    '--password': 'pwd'
+                    '--pubkeeper-token': 'pktoken'
                 })
                 config.assert_called_once_with(name='project',
                                                niohost='127.0.0.1',
                                                nioport='8181',
                                                pubkeeper_hostname='pkhost',
                                                pubkeeper_token='pktoken',
-                                               username='user',
-                                               password='pwd',
                                                ssl=None)
                 self.assertEqual(call.call_args_list[0][0][0], (
                     'git clone '

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -674,7 +674,7 @@ class TestCLI(unittest.TestCase):
             self.assertDictEqual(users[username],
                                  {"password": "AdminPwdHash"})
 
-            _set_permissions('testing_project', username)
+            _set_permissions('testing_project', username, False)
             # make sure we open permissions.json two times
             # to read and write new permissions
             self.assertEqual(mock_open.call_count, 4)


### PR DESCRIPTION
## Description
When a `--username` and `--password` are specified on `nio new` any other entries in etc/users.json should be overwritten. Specifying these flags on `nio config` will however append to etc/users.json

## JIRA Issue (Optional)
[NIO-1176](https://neutralio.atlassian.net/browse/NIO-1176)

## Todos
- [x] Tested and working locally
- [x] Unit Tests
- [x] Add a label to the PR