### PR TITLE
No username/password on config project

### DIFF
--- a/nio_cli/commands/config.py
+++ b/nio_cli/commands/config.py
@@ -29,8 +29,6 @@ class Config(Base):
             config_project(name=self.options['--project'],
                            pubkeeper_hostname=self.options.get('--pubkeeper-hostname'),
                            pubkeeper_token=self.options.get('--pubkeeper-token'),
-                           username=self.options['--username'],
-                           password=self.options['--password'],
                            ssl=self.options.get('--ssl'),
                            niohost=self.options['--ip'],
                            nioport=self.options['--port'])

--- a/nio_cli/utils.py
+++ b/nio_cli/utils.py
@@ -5,8 +5,7 @@ import tempfile
 from bcrypt import hashpw, gensalt
 
 def config_project(name='.', pubkeeper_hostname=None, pubkeeper_token=None,
-                   username=None, password=None, ssl=False, niohost=None,
-                   nioport=None):
+                   ssl=False, niohost=None, nioport=None):
     conf_location = '{}/nio.conf'.format(name)
     if not os.path.isfile(conf_location):
         print("Command must be run from project root.")
@@ -33,10 +32,6 @@ def config_project(name='.', pubkeeper_hostname=None, pubkeeper_token=None,
                 tmp.write(line)
     os.remove(conf_location)
     os.rename(tmp.name, conf_location)
-
-    # allow to set a user
-    if username or password:
-        set_user(name, username, password)
 
     if ssl:
         _config_ssl(name, conf_location)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,21 +117,6 @@ class TestConfigProject(unittest.TestCase):
         self.mock_os.remove.assert_called_once_with(conf_location)
         self.mock_os.rename.assert_called_once_with(ANY, conf_location)
 
-    def test_config_with_added_users(self):
-        pk_host = '123.pubkeeper.nio.works'
-        pk_token = '123123'
-        conf_location = './nio.conf'
-        users_location = './etc/users.json'
-        self._run_config_project(kwargs={"username": 'user',
-                                         "password": 'pwd',
-                                         "pubkeeper_hostname": pk_host,
-                                         "pubkeeper_token": pk_token})
-
-        self.assertEqual(self.mock_open.call_count, 5)
-        self._test_open_call_order(self.mock_open.call_args_list)
-        self.mock_os.remove.assert_called_once_with(conf_location)
-        self.mock_os.rename.assert_called_once_with(ANY, conf_location)
-
     def test_config_with_no_nioconf(self):
         self._run_config_project(isfile=False)
         self.mock_print.assert_called_once_with(
@@ -141,14 +126,11 @@ class TestConfigProject(unittest.TestCase):
     def test_config_with_ssl(self):
         pk_host = '123.pubkeeper.nio.works'
         pk_token = '123123'
-        self._run_config_project(kwargs={"username": 'user',
-                                         "password": 'pwd',
-                                         "pubkeeper_hostname": pk_host,
+        self._run_config_project(kwargs={"pubkeeper_hostname": pk_host,
                                          "pubkeeper_token": pk_token,
                                          "ssl": True})
 
-        self.assertEqual(self.mock_open.call_count, 5)
-        self._test_open_call_order(self.mock_open.call_args_list)
+        self.assertEqual(self.mock_open.call_count, 1)
         self.mock_os.remove.assert_called_once_with('./nio.conf')
         self.mock_os.rename.assert_called_once_with(ANY, './nio.conf')
         self.assertEqual(self.mock_ssl.call_count, 1)


### PR DESCRIPTION
## Description
with --username and password default to Admin. config was attempting to set an admin user each time it was called. we have `add_user` for this so the ability to add a user on config should be removed. 

## JIRA Issue (Optional)
[NIO-1176](https://neutralio.atlassian.net/browse/NIO-1176)

## Todos
- [X] Tested and working locally
- [X] Unit Tests
- [X] Add a label to the PR