### PR TITLE
NIO-1202, replacing `os.rename` calls with `shutil.move`

### DIFF
--- a/nio_cli/commands/newblock.py
+++ b/nio_cli/commands/newblock.py
@@ -1,4 +1,5 @@
 import subprocess, re
+from shutil import move
 
 from .base import Base
 import os
@@ -17,24 +18,27 @@ class NewBlock(Base):
         subprocess.call(clone, shell=True)
 
         # rename block file
+
+        # ensure working with absolute path, safer for 'move' operations since
+        # it will override if needed
         block_parent_path = os.path.abspath(".")
         block_root_path = os.path.join(block_parent_path, self._block)
         os.chdir(block_root_path)
-        os.rename(os.path.join(block_root_path, "example_block.py"),
-                  os.path.join(block_root_path,
-                               "{0}_block.py".format(self._block)))
+        move(os.path.join(block_root_path, "example_block.py"),
+             os.path.join(block_root_path,
+                          "{0}_block.py".format(self._block)))
 
         # rename readme
         os.remove(os.path.join(block_root_path, "README.md"))
-        os.rename(os.path.join(block_root_path, "BLOCK_README.md"),
-                  os.path.join(block_root_path, "README.md"))
+        move(os.path.join(block_root_path, "BLOCK_README.md"),
+             os.path.join(block_root_path, "README.md"))
 
         # rename test file
         block_tests_path = os.path.join(block_root_path, "tests")
         os.chdir(block_tests_path)
-        os.rename(os.path.join(block_tests_path, "test_example_block.py"),
-                  os.path.join(block_tests_path,
-                               "test_{0}_block.py".format(self._block)))
+        move(os.path.join(block_tests_path, "test_example_block.py"),
+             os.path.join(block_tests_path,
+                          "test_{0}_block.py".format(self._block)))
 
         # subsequent calls assume being on block's parent folder
         os.chdir(block_parent_path)

--- a/nio_cli/utils/project.py
+++ b/nio_cli/utils/project.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+from shutil import move
 
 from .ssl import config_ssl
 
@@ -40,4 +41,5 @@ def config_project(name='.', pubkeeper_hostname=None, pubkeeper_token=None,
             else:
                 tmp.write(line)
     os.remove(conf_location)
-    os.rename(tmp.name, conf_location)
+    # move file using full-path so that it overrides if needed
+    move(os.path.abspath(tmp.name), os.path.abspath(conf_location))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -536,7 +536,8 @@ class TestCLI(unittest.TestCase):
                    mock_open(
                        read_data='Example ..example_block TestExample')
                    ) as mock_file, \
-                patch("nio_cli.commands.newblock.os") as os_mock:
+                patch("nio_cli.commands.newblock.os") as os_mock, \
+                patch("nio_cli.commands.newblock.move") as move_mock:
 
             self._main('newblock', **{'<block-name>': 'yaba_daba'})
             self.assertEqual(call.call_args_list[0][0][0], (
@@ -550,7 +551,7 @@ class TestCLI(unittest.TestCase):
                 'YabaDaba ..example_block TestYabaDaba')
             # assert calls to rename block files
             self.assertEqual(os_mock.remove.call_count, 1)
-            self.assertEqual(os_mock.rename.call_count, 3)
+            self.assertEqual(move_mock.call_count, 3)
 
     def test_blockcheck_command(self):
         self.maxDiff = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,7 @@ class TestConfigProject(unittest.TestCase):
         with patch('builtins.open', mock_open()) as self.mock_open, \
                 patch('builtins.print') as self.mock_print, \
                 patch(config_project.__module__ + '.os') as self.mock_os, \
+                patch(config_project.__module__ + '.move') as self.mock_move, \
                 patch(config_project.__module__ + '.config_ssl') as self.mock_ssl:
             self.mock_ssl.return_value = ('path/to/cert', 'path/to/key')
             self.mock_os.path.isfile.return_value = isfile
@@ -42,7 +43,7 @@ class TestConfigProject(unittest.TestCase):
         self.assertEqual(self.mock_open.call_args_list[0],
             call('./nio.conf', 'r'))
         self.mock_os.remove.assert_called_once_with('./nio.conf')
-        self.mock_os.rename.assert_called_once_with(ANY, './nio.conf')
+        self.mock_move.assert_called_once_with(ANY, ANY)
         self.assertEqual(self.mock_ssl.call_count, 0)
 
     def test_config_with_pubkeeper_port_ip_flags(self):
@@ -56,7 +57,7 @@ class TestConfigProject(unittest.TestCase):
         self.assertEqual(self.mock_open.call_args_list[0],
             call('./nio.conf', 'r'))
         self.mock_os.remove.assert_called_once_with('./nio.conf')
-        self.mock_os.rename.assert_called_once_with(ANY, './nio.conf')
+        self.mock_move.assert_called_once_with(ANY, ANY)
 
     def test_config_with_specified_project_location(self):
         pk_host = '123.pubkeeper.nio.works'
@@ -71,7 +72,7 @@ class TestConfigProject(unittest.TestCase):
         self.assertEqual(self.mock_open.call_args_list[0],
             call(conf_location, 'r'))
         self.mock_os.remove.assert_called_once_with(conf_location)
-        self.mock_os.rename.assert_called_once_with(ANY, conf_location)
+        self.mock_move.assert_called_once_with(ANY, ANY)
 
     def test_config_with_no_nioconf(self):
         self._run_config_project(isfile=False)
@@ -88,7 +89,7 @@ class TestConfigProject(unittest.TestCase):
 
         self.assertEqual(self.mock_open.call_count, 1)
         self.mock_os.remove.assert_called_once_with('./nio.conf')
-        self.mock_os.rename.assert_called_once_with(ANY, './nio.conf')
+        self.mock_move.assert_called_once_with(ANY, ANY)
         self.assertEqual(self.mock_ssl.call_count, 1)
 
     def _test_open_call_order(self, call_args_list, path='.'):


### PR DESCRIPTION
## Description
Any additional info regarding implementation and how to replicate locally

## JIRA Issue (Optional)
[NIO-xyz](https://neutralio.atlassian.net/browse/NIO-xyz)

## Todos
- [X] Tested and working locally
- [X] Unit Tests
- [ ] Updated [documentation](https://github.com/niolabs/docs)
- [ ] Add a label to the PR